### PR TITLE
Feat/add e2e test and evals

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,15 @@ On Windows: `%APPDATA%/Claude/claude_desktop_config.json`
 - "Can you please plot the stake distribution of EigenDA operators?"
 - "How many stakers are there on EigenDA AVS"
 
+
+
+## Running evals
+
+The evals package loads an mcp client that then runs the index.ts file, so there is no need to rebuild between tests. You can load environment variables by prefixing the npx command. Full documentation can be found [here](https://www.mcpevals.io/docs).
+
+```bash
+OPENAI_API_KEY=your-key  npx mcp-eval src/evals/evals.ts src/core/tools.ts
+```
 ## License
 
 This project is licensed under the MIT License - see the [LICENSE](LICENSE) file for details.

--- a/README.md
+++ b/README.md
@@ -133,18 +133,17 @@ On Windows: `%APPDATA%/Claude/claude_desktop_config.json`
 - "Can you please plot the stake distribution of EigenDA operators?"
 - "How many stakers are there on EigenDA AVS"
 
+## License
 
+This project is licensed under the MIT License - see the [LICENSE](LICENSE) file for details.
 
 ## Running evals
 
 The evals package loads an mcp client that then runs the index.ts file, so there is no need to rebuild between tests. You can load environment variables by prefixing the npx command. Full documentation can be found [here](https://www.mcpevals.io/docs).
 
 ```bash
-OPENAI_API_KEY=your-key  npx mcp-eval src/evals/evals.ts src/core/tools.ts
+OPENAI_API_KEY=your-key  npx mcp-eval src/evals/evals.ts src/index.ts
 ```
-## License
-
-This project is licensed under the MIT License - see the [LICENSE](LICENSE) file for details.
 
 ## Acknowledgments
 

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.10.2",
-    "axios": "^1.9.0"
+    "axios": "^1.9.0",
+    "mcp-evals": "^1.0.18"
   }
 }

--- a/src/evals/evals.ts
+++ b/src/evals/evals.ts
@@ -1,0 +1,59 @@
+//evals.ts
+
+import { EvalConfig } from 'mcp-evals';
+import { openai } from "@ai-sdk/openai";
+import { grade, EvalFunction } from "mcp-evals";
+
+const get_dex_pair_metrics: EvalFunction = {
+    name: "get_dex_pair_metrics Tool Evaluation",
+    description: "Evaluates the get_dex_pair_metrics tool functionality",
+    run: async () => {
+        const result = await grade(openai("gpt-4"), "Retrieve the DEX metrics for the ETH/USDC token pair on Ethereum");
+        return JSON.parse(result);
+    }
+};
+
+const get_token_pairs_liquidityEval: EvalFunction = {
+    name: 'get_token_pairs_liquidity Evaluation',
+    description: 'Evaluates the process of identifying the token pair with the highest USD liquidity on a given chain',
+    run: async () => {
+        const result = await grade(openai("gpt-4"), "Which token pair has the highest USD liquidity on the BSC chain?");
+        return JSON.parse(result);
+    }
+};
+
+const get_svm_token_balancesEval: EvalFunction = {
+    name: 'get_svm_token_balances Tool Evaluation',
+    description: 'Evaluates retrieving token balances from a Solana wallet address',
+    run: async () => {
+        const result = await grade(openai("gpt-4"), "What are the token balances for the Solana wallet address 8b5TqHqh8B8qSoS6LnvarTRbTT6JBBNpf7voNsZX5Eiu?");
+        return JSON.parse(result);
+    }
+};
+
+const get_eigenlayer_avs_metricsEval: EvalFunction = {
+  name: "get_eigenlayer_avs_metrics Evaluation",
+  description: "Evaluates the correctness of the get_eigenlayer_avs_metrics tool by asking about a specific AVS's stats",
+  run: async () => {
+    const result = await grade(openai("gpt-4"), "Retrieve the metrics for the AVS named 'exampleAvs' using the get_eigenlayer_avs_metrics tool.");
+    return JSON.parse(result);
+  }
+};
+
+const get_eigenlayer_operator_metricsEval: EvalFunction = {
+    name: 'Get Eigenlayer Operator Metrics Tool Evaluation',
+    description: 'Evaluates the retrieval of operator statistics for a specified AVS',
+    run: async () => {
+        const result = await grade(openai("gpt-4"), "Please provide the operator metrics for the AVS named 'TestAVS'.");
+        return JSON.parse(result);
+    }
+};
+
+const config: EvalConfig = {
+    model: openai("gpt-4"),
+    evals: [get_dex_pair_metrics, get_token_pairs_liquidityEval, get_svm_token_balancesEval, get_eigenlayer_avs_metricsEval, get_eigenlayer_operator_metricsEval]
+};
+  
+export default config;
+  
+export const evals = [get_dex_pair_metrics, get_token_pairs_liquidityEval, get_svm_token_balancesEval, get_eigenlayer_avs_metricsEval, get_eigenlayer_operator_metricsEval];


### PR DESCRIPTION
Adds new e2e test that loads an MCP client, which in turn runs the server and processes the actual tool call. Afterwards, it then grades the response for correctness. 

note: I'm the package author 